### PR TITLE
feat: Rebuild committee overview dashboard with dark theme

### DIFF
--- a/app/routes/surtax.py
+++ b/app/routes/surtax.py
@@ -27,13 +27,24 @@ def overview():
         cat_budget = cat.get('total_budget', 0) or 0
         cat['percent_of_total'] = round(cat_budget / total_budget * 100, 1) if total_budget > 0 else 0
 
+    # Get specific delayed/overbudget project details for the overview cards
+    delayed_details = [c for c in concerns if c.get('is_delayed')]
+    overbudget_details = [c for c in concerns if c.get('is_over_budget')]
+
+    # Budget utilization percent
+    total_spent = stats.get('total_spent', 0) or 0
+    budget_pct = round(total_spent / total_budget * 100, 1) if total_budget > 0 else 0
+
     return render_template(template,
-                          title='Surtax Overview',
+                          title='Oversight Committee Portal',
                           stats=stats,
                           categories=categories,
                           concerns=concerns,
                           delayed_projects=stats.get('delayed_count', 0),
                           overbudget_projects=stats.get('over_budget_count', 0),
+                          delayed_details=delayed_details,
+                          overbudget_details=overbudget_details,
+                          budget_pct=budget_pct,
                           quick_stats={
                               'active_projects': stats.get('active_projects', 0),
                               'total_budget': f"${stats.get('total_budget', 0)/1_000_000:,.1f}M" if stats.get('total_budget') else '$0'

--- a/app/templates/surtax/committee_overview.html
+++ b/app/templates/surtax/committee_overview.html
@@ -1,231 +1,277 @@
 {% extends "base.html" %}
 
+{% block page_title %}Oversight Committee Portal{% endblock %}
+{% block page_subtitle %}School Capital Outlay Surtax Oversight Committee{% endblock %}
+
 {% block content %}
-<!-- Simplified Committee Member Dashboard -->
+<style>
+    /* Override light background for this page */
+    main { background: #0f172a !important; }
+    main > div { padding: 1.5rem !important; }
+    .kpi-card {
+        border-radius: 0.75rem; padding: 1.25rem 1.5rem; position: relative; overflow: hidden;
+        min-height: 110px; display: flex; flex-direction: column; justify-content: center;
+    }
+    .kpi-card .kpi-icon {
+        position: absolute; right: 1rem; top: 50%; transform: translateY(-50%);
+        width: 2.5rem; height: 2.5rem; border-radius: 50%;
+        display: flex; align-items: center; justify-content: center; opacity: 0.9;
+    }
+    .kpi-card .kpi-label { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.9; }
+    .kpi-card .kpi-value { font-size: 2rem; font-weight: 800; line-height: 1.1; margin-top: 0.25rem; }
+    .kpi-card .kpi-sub { font-size: 0.75rem; opacity: 0.8; margin-top: 0.25rem; }
+    .dark-card { background: #1e293b; border: 1px solid #334155; border-radius: 0.75rem; }
+</style>
 
-<!-- Header -->
-<div class="mb-8">
-    <h1 class="text-3xl font-bold text-gray-900">Overview</h1>
-    <p class="text-gray-500 mt-1">Your at-a-glance dashboard for oversight committee duties</p>
-</div>
+<!-- Header: County Name + Persona + Action Buttons -->
+<div class="flex flex-col lg:flex-row lg:items-start lg:justify-between mb-6">
+    <div>
+        <div class="flex items-baseline gap-3">
+            <h1 class="text-3xl font-bold text-white">Marion County Schools</h1>
+            <span class="text-xs font-medium text-slate-400 uppercase tracking-wider">Now</span>
+        </div>
+        <p class="text-sm text-slate-400 mt-1">School Capital Outlay Surtax Oversight Committee</p>
 
-<!-- Section 1: Items Requiring Attention -->
-<div class="bg-white rounded-xl shadow-sm p-6 mb-6">
-    <h2 class="text-xl font-bold text-gray-900 mb-4 flex items-center gap-2">
-        <svg class="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-        </svg>
-        Items Requiring Attention
-    </h2>
-
-    {% if delayed_projects > 0 %}
-    <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-3">
-        <div class="flex items-start gap-3">
-            <div class="flex-shrink-0 w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                <span class="text-red-600 font-bold text-lg">{{ delayed_projects }}</span>
+        <!-- Persona Badge -->
+        <div class="flex items-center gap-3 mt-3">
+            <div class="flex items-center gap-2">
+                <div class="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center text-white text-xs font-bold">
+                    {{ persona_config.name[:1] }}{{ persona_config.name.split(' ')[-1][:1] if ' ' in persona_config.name else '' }}
+                </div>
+                <div>
+                    <p class="text-xs text-slate-400 uppercase tracking-wider font-semibold">{{ 'Committee Member' if current_persona == 'committee' else 'District Staff' }}</p>
+                    <p class="text-sm text-white font-medium">{{ persona_config.name }}</p>
+                </div>
             </div>
-            <div class="flex-1">
-                <h3 class="font-semibold text-gray-900 mb-1">Projects Behind Schedule</h3>
-                <p class="text-sm text-gray-600 mb-2">Multiple projects experiencing delays</p>
-                <a href="{{ url_for('surtax.concerns') }}" class="text-sm text-blue-600 hover:text-blue-700 font-medium">View details &rarr;</a>
-            </div>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-500/20 text-green-400 border border-green-500/30">
+                Active Session
+            </span>
         </div>
     </div>
-    {% endif %}
 
-    {% if overbudget_projects > 0 %}
-    <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
-        <div class="flex items-start gap-3">
-            <div class="flex-shrink-0 w-10 h-10 bg-amber-100 rounded-full flex items-center justify-center">
-                <span class="text-amber-600 font-bold text-lg">{{ overbudget_projects }}</span>
-            </div>
-            <div class="flex-1">
-                <h3 class="font-semibold text-gray-900 mb-1">Projects Over Budget</h3>
-                <p class="text-sm text-gray-600 mb-2">Budget variances detected</p>
-                <a href="{{ url_for('surtax.concerns') }}" class="text-sm text-blue-600 hover:text-blue-700 font-medium">View details &rarr;</a>
-            </div>
-        </div>
+    <!-- Action Buttons -->
+    <div class="flex items-center gap-2 mt-4 lg:mt-0">
+        <a href="{{ url_for('switch_persona', persona_id='staff') }}"
+           class="inline-flex items-center gap-1.5 px-3 py-2 bg-slate-700 text-slate-200 text-sm font-medium rounded-lg hover:bg-slate-600 transition-colors border border-slate-600">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"/></svg>
+            Full Dashboard
+        </a>
+        <a href="{{ url_for('documents.report') }}"
+           class="inline-flex items-center gap-1.5 px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            Export PDF
+        </a>
+        <button onclick="document.documentElement.requestFullscreen()"
+                class="inline-flex items-center gap-1.5 px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"/></svg>
+            Fullscreen
+        </button>
     </div>
-    {% endif %}
-
-    {% if delayed_projects == 0 and overbudget_projects == 0 %}
-    <div class="text-center py-8">
-        <svg class="w-16 h-16 text-green-500 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-        </svg>
-        <p class="text-gray-600 font-medium">All projects on track</p>
-        <p class="text-sm text-gray-500 mt-1">No concerns at this time</p>
-    </div>
-    {% endif %}
 </div>
 
-<!-- Section 2: Revenue & Spending Snapshot -->
-<div class="bg-white rounded-xl shadow-sm p-6 mb-6">
-    <div class="flex items-center justify-between mb-4">
-        <h2 class="text-xl font-bold text-gray-900 flex items-center gap-2">
-            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-            </svg>
-            Revenue & Spending Snapshot
+<!-- Key Points + AI Assistant -->
+<div class="grid grid-cols-1 lg:grid-cols-4 gap-4 mb-6">
+    <!-- Key Points (3/4 width) -->
+    <div class="lg:col-span-3 dark-card p-5">
+        <h2 class="text-base font-bold text-white mb-3 flex items-center gap-2">
+            <div class="w-8 h-8 bg-blue-600/20 rounded-lg flex items-center justify-center">
+                <svg class="w-5 h-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
+                </svg>
+            </div>
+            Key Points to Consider for This Meeting
         </h2>
-        <a href="{{ url_for('financials.home') }}" class="text-sm text-blue-600 hover:text-blue-700 font-medium">View full financials &rarr;</a>
-    </div>
-
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-        <div class="text-center p-4 bg-gray-50 rounded-lg">
-            <p class="text-2xl font-bold text-gray-900">{{ stats.total_budget|currency }}</p>
-            <p class="text-sm text-gray-600">Total Budget</p>
-        </div>
-        <div class="text-center p-4 bg-blue-50 rounded-lg">
-            <p class="text-2xl font-bold text-blue-600">{{ stats.total_spent|currency }}</p>
-            <p class="text-sm text-gray-600">Spent to Date</p>
-        </div>
-        <div class="text-center p-4 bg-green-50 rounded-lg">
-            <p class="text-2xl font-bold text-green-600">{{ (stats.total_spent / stats.total_budget * 100)|round(1) if stats.total_budget else 0 }}%</p>
-            <p class="text-sm text-gray-600">Budget Used</p>
-        </div>
-    </div>
-
-    <div class="space-y-3">
-        <p class="text-sm font-medium text-gray-700">Top Spending Categories:</p>
-        {% for cat in categories[:3] %}
-        <div>
-            <div class="flex justify-between text-sm mb-1">
-                <span class="text-gray-700">{{ cat.category }}</span>
-                <span class="font-medium">{{ cat.total_budget|currency }} ({{ cat.percent_of_total|round }}%)</span>
-            </div>
-            <div class="w-full bg-gray-200 rounded-full h-2.5">
-                <div class="h-2.5 rounded-full bg-blue-600" style="width: {{ cat.percent_of_total }}%"></div>
-            </div>
-        </div>
-        {% endfor %}
-    </div>
-</div>
-
-<!-- Section 3: Project Portfolio Overview -->
-<div class="bg-white rounded-xl shadow-sm p-6 mb-6">
-    <div class="flex items-center justify-between mb-4">
-        <h2 class="text-xl font-bold text-gray-900 flex items-center gap-2">
-            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
-            </svg>
-            Project Portfolio
-        </h2>
-        <a href="{{ url_for('surtax.projects') }}" class="text-sm text-blue-600 hover:text-blue-700 font-medium">View all projects &rarr;</a>
-    </div>
-
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div class="text-center p-4 border border-gray-200 rounded-lg">
-            <p class="text-3xl font-bold text-gray-900">{{ stats.total_projects }}</p>
-            <p class="text-sm text-gray-600">Total Projects</p>
-        </div>
-        <div class="text-center p-4 border border-gray-200 rounded-lg">
-            <p class="text-3xl font-bold text-green-600">{{ stats.active_projects }}</p>
-            <p class="text-sm text-gray-600">Active</p>
-        </div>
-        <div class="text-center p-4 border border-gray-200 rounded-lg">
-            <p class="text-3xl font-bold text-blue-600">{{ stats.avg_completion|round if stats.avg_completion else 0 }}%</p>
-            <p class="text-sm text-gray-600">Avg Completion</p>
-        </div>
-        <div class="text-center p-4 border border-gray-200 rounded-lg">
-            <p class="text-3xl font-bold text-green-600">{{ stats.completed_projects }}</p>
-            <p class="text-sm text-gray-600">Completed</p>
-        </div>
-    </div>
-</div>
-
-<!-- Section 4: Key Documents & Meeting Prep -->
-<div class="bg-white rounded-xl shadow-sm p-6 mb-6">
-    <h2 class="text-xl font-bold text-gray-900 mb-4 flex items-center gap-2">
-        <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-        </svg>
-        Key Documents & Meeting Prep
-    </h2>
-
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <a href="{{ url_for('tools.meeting') }}" class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-blue-300 transition-colors">
-            <svg class="w-8 h-8 text-blue-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-            </svg>
-            <div>
-                <p class="font-medium text-gray-900">Prepare for Meeting</p>
-                <p class="text-xs text-gray-500">Agenda, talking points, key questions</p>
-            </div>
-        </a>
-        <a href="{{ url_for('documents.minutes') }}" class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-blue-300 transition-colors">
-            <svg class="w-8 h-8 text-gray-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-            </svg>
-            <div>
-                <p class="font-medium text-gray-900">Meeting Minutes</p>
-                <p class="text-xs text-gray-500">Past meeting records</p>
-            </div>
-        </a>
-        <a href="{{ url_for('documents.report') }}" class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-blue-300 transition-colors">
-            <svg class="w-8 h-8 text-gray-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-            </svg>
-            <div>
-                <p class="font-medium text-gray-900">Annual Report</p>
-                <p class="text-xs text-gray-500">Yearly oversight summary</p>
-            </div>
-        </a>
-        <a href="{{ url_for('documents.home') }}" class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-blue-300 transition-colors">
-            <svg class="w-8 h-8 text-gray-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
-            </svg>
-            <div>
-                <p class="font-medium text-gray-900">All Documents</p>
-                <p class="text-xs text-gray-500">Full document library</p>
-            </div>
-        </a>
-    </div>
-
-    <div class="mt-6 p-4 bg-amber-50 border border-amber-200 rounded-lg">
-        <h3 class="font-semibold text-gray-900 mb-2 flex items-center gap-2">
-            <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
-            </svg>
-            Key Points to Consider:
-        </h3>
-        <ul class="space-y-1 text-sm text-gray-700">
-            <li class="flex items-start gap-2"><span class="text-amber-600 mt-0.5">&bull;</span><span>How does year-to-date revenue compare with projections?</span></li>
-            <li class="flex items-start gap-2"><span class="text-amber-600 mt-0.5">&bull;</span><span>Do current expenditures align with ballot language and capital outlay requirements?</span></li>
-            <li class="flex items-start gap-2"><span class="text-amber-600 mt-0.5">&bull;</span><span>What is the district's multi-year forecast and contingency plan?</span></li>
-            <li class="flex items-start gap-2"><span class="text-amber-600 mt-0.5">&bull;</span><span>How is the district communicating surtax spending to the public?</span></li>
+        <ul class="space-y-2.5">
+            <li class="flex items-start gap-2.5">
+                <span class="w-2 h-2 bg-amber-400 rounded-full mt-1.5 flex-shrink-0"></span>
+                <span class="text-sm text-slate-300">Review year-to-date revenue collections vs. projections and assess impact on approved project timeline</span>
+            </li>
+            <li class="flex items-start gap-2.5">
+                <span class="w-2 h-2 bg-amber-400 rounded-full mt-1.5 flex-shrink-0"></span>
+                <span class="text-sm text-slate-300">Verify all surtax expenditures align with ballot language and capital outlay statutory requirements</span>
+            </li>
+            <li class="flex items-start gap-2.5">
+                <span class="w-2 h-2 bg-amber-400 rounded-full mt-1.5 flex-shrink-0"></span>
+                <span class="text-sm text-slate-300">Request updated forecast and contingency plans for potential revenue shortfalls</span>
+            </li>
+            <li class="flex items-start gap-2.5">
+                <span class="w-2 h-2 bg-amber-400 rounded-full mt-1.5 flex-shrink-0"></span>
+                <span class="text-sm text-slate-300">Discuss public communication strategy regarding project status and budget adjustments</span>
+            </li>
         </ul>
     </div>
+
+    <!-- AI Assistant Card (1/4 width) -->
+    <a href="{{ url_for('tools.ask') }}" class="dark-card p-5 flex flex-col items-center justify-center text-center hover:border-blue-500/50 transition-colors group">
+        <div class="w-14 h-14 bg-blue-600/20 rounded-2xl flex items-center justify-center mb-3 group-hover:bg-blue-600/30 transition-colors">
+            <svg class="w-7 h-7 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
+            </svg>
+        </div>
+        <h3 class="text-white font-semibold text-sm">Ask AI Assistant</h3>
+        <p class="text-slate-400 text-xs mt-1">Get instant answers about projects & data</p>
+    </a>
 </div>
 
-<!-- Section 5: Guided AI Assistant -->
-<div class="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-xl shadow-sm p-6 mb-6">
-    <h2 class="text-xl font-bold text-gray-900 mb-2 flex items-center gap-2">
-        <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
-        </svg>
-        Ask AI Assistant
-    </h2>
-    <p class="text-sm text-gray-600 mb-4">Get instant answers to common oversight questions</p>
-    <div class="flex items-center gap-3">
-        <a href="{{ url_for('tools.ask') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
-            </svg>
-            Open AI Assistant
-        </a>
-        <span class="text-sm text-gray-600">Get answers about revenue, projects, compliance & more</span>
+<!-- Portfolio Summary: 4 KPI Cards -->
+<h2 class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">Portfolio Summary</h2>
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+    <!-- Total Projects (Green) -->
+    <div class="kpi-card" style="background: linear-gradient(135deg, #059669, #10b981);">
+        <div class="kpi-icon" style="background: rgba(255,255,255,0.2);">
+            <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
+        </div>
+        <span class="kpi-label text-white">Total Projects</span>
+        <span class="kpi-value text-white">{{ stats.total_projects }}</span>
+        <span class="kpi-sub text-white">{{ stats.active_projects }} active</span>
+    </div>
+
+    <!-- Total Budget (Blue) -->
+    <div class="kpi-card" style="background: linear-gradient(135deg, #2563eb, #3b82f6);">
+        <div class="kpi-icon" style="background: rgba(255,255,255,0.2);">
+            <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+        </div>
+        <span class="kpi-label text-white">Total Budget</span>
+        <span class="kpi-value text-white">${{ "%.1f"|format(stats.total_budget / 1000000) }}M</span>
+        <span class="kpi-sub text-white">{{ budget_pct }}% committed</span>
+    </div>
+
+    <!-- Spent to Date (Orange) -->
+    <div class="kpi-card" style="background: linear-gradient(135deg, #d97706, #f59e0b);">
+        <div class="kpi-icon" style="background: rgba(255,255,255,0.2);">
+            <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
+        </div>
+        <span class="kpi-label text-white">Spent to Date</span>
+        <span class="kpi-value text-white">${{ "%.1f"|format(stats.total_spent / 1000000) }}M</span>
+        <span class="kpi-sub text-white">{{ budget_pct }}% of budget</span>
+    </div>
+
+    <!-- Avg Completion (Purple) -->
+    <div class="kpi-card" style="background: linear-gradient(135deg, #7c3aed, #8b5cf6);">
+        <div class="kpi-icon" style="background: rgba(255,255,255,0.2);">
+            <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+        </div>
+        <span class="kpi-label text-white">Avg Completion</span>
+        <span class="kpi-value text-white">{{ stats.avg_completion|round|int if stats.avg_completion else 0 }}%</span>
+        <span class="kpi-sub text-white">{{ stats.completed_projects }} completed</span>
     </div>
 </div>
 
-<!-- Staff View Escape Hatch -->
-<div class="text-center pb-4">
-    <p class="text-sm text-gray-500 mb-2">Need access to advanced analytics and detailed reports?</p>
-    <a href="{{ url_for('switch_persona', persona_id='staff') }}" class="inline-flex items-center gap-2 text-sm text-blue-600 hover:text-blue-700 font-medium">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
-        </svg>
-        Switch to Staff View
+<!-- Items Requiring Attention -->
+<h2 class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">Items Requiring Attention</h2>
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+    <!-- Projects Behind Schedule -->
+    <div class="dark-card p-5">
+        <div class="flex items-center gap-3 mb-4">
+            <div class="w-10 h-10 bg-amber-500/20 rounded-full flex items-center justify-center">
+                <svg class="w-5 h-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+            </div>
+            <div>
+                <p class="text-3xl font-bold text-amber-400">{{ delayed_projects }}</p>
+                <p class="text-sm text-slate-400">Projects Behind Schedule</p>
+            </div>
+        </div>
+        {% if delayed_details %}
+        <div class="border-t border-slate-700 pt-3">
+            <p class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Affected Projects:</p>
+            <ul class="space-y-1.5">
+                {% for p in delayed_details[:5] %}
+                <li class="flex items-center gap-2 text-sm">
+                    <span class="w-1.5 h-1.5 bg-amber-400 rounded-full flex-shrink-0"></span>
+                    <span class="text-slate-300">{{ p.title }}</span>
+                    <span class="text-slate-500 ml-auto text-xs">{{ p.delay_days }} days delayed</span>
+                </li>
+                {% endfor %}
+            </ul>
+            <a href="{{ url_for('surtax.concerns') }}" class="inline-block mt-3 text-sm text-blue-400 hover:text-blue-300 font-medium">
+                Click to review details &rarr;
+            </a>
+        </div>
+        {% else %}
+        <div class="border-t border-slate-700 pt-3">
+            <p class="text-sm text-slate-500">All projects on schedule</p>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- Projects Over Budget -->
+    <div class="dark-card p-5">
+        <div class="flex items-center gap-3 mb-4">
+            <div class="w-10 h-10 bg-red-500/20 rounded-full flex items-center justify-center">
+                <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                </svg>
+            </div>
+            <div>
+                <p class="text-3xl font-bold text-red-400">{{ overbudget_projects }}</p>
+                <p class="text-sm text-slate-400">Projects Over Budget</p>
+            </div>
+        </div>
+        {% if overbudget_details %}
+        <div class="border-t border-slate-700 pt-3">
+            <p class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Budget Overruns:</p>
+            <ul class="space-y-1.5">
+                {% for p in overbudget_details[:5] %}
+                <li class="flex items-center gap-2 text-sm">
+                    <span class="w-1.5 h-1.5 bg-red-400 rounded-full flex-shrink-0"></span>
+                    <span class="text-slate-300">{{ p.title }}</span>
+                    <span class="text-slate-500 ml-auto text-xs">
+                        +${{ "%.0f"|format((p.current_amount - (p.current_amount / (1 + p.budget_variance_pct/100))) / 1000) if p.budget_variance_pct else '0' }}K ({{ p.budget_variance_pct|round(1) if p.budget_variance_pct else 0 }}%)
+                    </span>
+                </li>
+                {% endfor %}
+            </ul>
+            <a href="{{ url_for('surtax.concerns') }}" class="inline-block mt-3 text-sm text-blue-400 hover:text-blue-300 font-medium">
+                Click to review details &rarr;
+            </a>
+        </div>
+        {% else %}
+        <div class="border-t border-slate-700 pt-3">
+            <p class="text-sm text-slate-500">All projects within budget</p>
+        </div>
+        {% endif %}
+    </div>
+</div>
+
+<!-- Quick Navigation Row -->
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+    <a href="{{ url_for('surtax.projects') }}" class="dark-card p-4 flex items-center gap-3 hover:border-blue-500/50 transition-colors group">
+        <div class="w-10 h-10 bg-blue-600/20 rounded-lg flex items-center justify-center group-hover:bg-blue-600/30 transition-colors">
+            <svg class="w-5 h-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/></svg>
+        </div>
+        <div>
+            <p class="text-sm font-medium text-white">Browse Projects</p>
+            <p class="text-xs text-slate-400">{{ stats.total_projects }} projects</p>
+        </div>
+    </a>
+    <a href="{{ url_for('tools.meeting') }}" class="dark-card p-4 flex items-center gap-3 hover:border-blue-500/50 transition-colors group">
+        <div class="w-10 h-10 bg-purple-600/20 rounded-lg flex items-center justify-center group-hover:bg-purple-600/30 transition-colors">
+            <svg class="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
+        </div>
+        <div>
+            <p class="text-sm font-medium text-white">Meeting Mode</p>
+            <p class="text-xs text-slate-400">Prepare & present</p>
+        </div>
+    </a>
+    <a href="{{ url_for('documents.report') }}" class="dark-card p-4 flex items-center gap-3 hover:border-blue-500/50 transition-colors group">
+        <div class="w-10 h-10 bg-green-600/20 rounded-lg flex items-center justify-center group-hover:bg-green-600/30 transition-colors">
+            <svg class="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+        </div>
+        <div>
+            <p class="text-sm font-medium text-white">Annual Report</p>
+            <p class="text-xs text-slate-400">Compliance report</p>
+        </div>
+    </a>
+    <a href="{{ url_for('tools.compliance') }}" class="dark-card p-4 flex items-center gap-3 hover:border-blue-500/50 transition-colors group">
+        <div class="w-10 h-10 bg-amber-600/20 rounded-lg flex items-center justify-center group-hover:bg-amber-600/30 transition-colors">
+            <svg class="w-5 h-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+        </div>
+        <div>
+            <p class="text-sm font-medium text-white">Compliance</p>
+            <p class="text-xs text-slate-400">Oversight checks</p>
+        </div>
     </a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Rebuilt committee overview dashboard to match slide deck design
- Dark theme main content area with gradient KPI cards
- Persona badge with active session indicator
- Key Meeting Points callout with AI Assistant card
- Items Requiring Attention with specific project names, delay days, and budget overrun details
- Quick navigation row for Browse Projects, Meeting Mode, Annual Report, Compliance

Closes #3

## Test plan
- [ ] Verify overview renders at `/surtax/` with committee persona
- [ ] Check KPI cards show correct data from DB
- [ ] Verify delayed/overbudget project details appear
- [ ] Test responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)